### PR TITLE
Delete focus-areas/sustainability directory

### DIFF
--- a/focus-areas/sustainability/README.md
+++ b/focus-areas/sustainability/README.md
@@ -1,7 +1,0 @@
-## Sustainability
-
-**Goal:** 
-
-| Metric | Why You Care | Implementation |
-| --- | --- | -- |
-| [MetricModelName](metric-model.md)| Why you care | Toolkit or Jupyter Notebook |


### PR DESCRIPTION
I would like to delete this directory. As we are now reworking the metrics models repository design a bit, this directory is no longer needed. There is no material that is being deleted with the removal of this directory, only the empty directory itself.