### PR TITLE
Delete focus-areas/community-engagement directory

### DIFF
--- a/focus-areas/community-engagement/README.md
+++ b/focus-areas/community-engagement/README.md
@@ -1,8 +1,0 @@
-## Community Engagement
-
-**Goal:** 
-
-| Metric | Why You Care | Implementation |
-| --- | --- | -- |
-| [MetricModelName](metric-model.md)| Why you care | Toolkit or Jupyter Notebook |
-


### PR DESCRIPTION
**Signed-off-by: Matt Germonprez [germonprez@gmail.com](mailto:germonprez@gmail.com)**

I would like to delete this directory. As we are now reworking the metrics models repository design a bit, this directory is no longer needed. There is no material that is being deleted with the removal of this directory, only the empty directory itself.