### PR TITLE
Adds permalinks where available

### DIFF
--- a/metrics-model-libs/community-activity/definition/community-activity.md
+++ b/metrics-model-libs/community-activity/definition/community-activity.md
@@ -14,12 +14,12 @@ In order for an open source project to be sustainable, it must continue to be ma
 
 
 # Metrics in the Metrics Model 
-* [Contributors](https://chaoss.community/metric-contributors/) 
+* [Contributors](https://chaoss.community/?p=3467)
     * contributor_count : Determine how many active commit authors, review participants, issue authors, and issue comments participants there are in the past 90 days.
     * maintainer_count : Determine the average number of maintainers per repository.
-* [Code Changes Commits](https://chaoss.community/metric-code-changes-commits/)
+* [Code Changes Commits](TBD)
     * commit_frequency : Determine the average number of commits per week in the past 90 days.
-* [Activity Dates and Times](https://chaoss.community/metric-activity-dates-and-times/)
+* [Activity Dates and Times](https://chaoss.community/?p=3444)
     * updated_since : Determine the average time per repository since the repository was last updated (in months).
     * created_since : Determine the average time per repository since a repository was created (in months).
     * comment_frequency : Determine the average number of comments per issue in the last 90 days.
@@ -27,11 +27,11 @@ In order for an open source project to be sustainable, it must continue to be ma
     * recent_releases_count : Determine the number of releases in the last year
     * meeting_count : Determine the number of meetings held in the last 90 days
     * meeting_attendee_count: Determine the average number of attendees per meeting
-* [Contribution Attribution](https://chaoss.community/metric-contribution-attribution/) 
+* [Contribution Attribution](https://chaoss.community/?p=3616) 
     * org_count : Determine the number of distinct organizations that contributors belong to
-* [Change Request Reviews](https://chaoss.community/metric-change-request-reviews/)
+* [Change Request Reviews](TBD)
     * code_review_count : Determine the average number of review comments per pull request in the last 90 days
-* [Issues Closed](https://chaoss.community/metric-issues-closed/)
+* [Issues Closed](https://chaoss.community/?p=3633)
     * closed_issues_count : Determine the number of issues closed in the last 90 day
 
 

--- a/metrics-model-libs/community-service-and-support/definition/community-service-and-support.md
+++ b/metrics-model-libs/community-service-and-support/definition/community-service-and-support.md
@@ -12,28 +12,29 @@ Community Service and Support measures the quality of services and support provi
 
 # Metrics in the Metrics Model
 
-- [Issue Response Time](https://chaoss.community/metric-issue-response-time/)
+- [Issue Response Time](https://chaoss.community/?p=3631)
 Average/Median first comments response (in days) for new issues created in the last 90 days. This excludes bot responses, the creator's own comment, or an action assigned by the issue. If the issue has been unanswered, the first response time is not counted.
-- [Issue Age](https://chaoss.community/metric-issue-age/)
+- [Issue Age](https://chaoss.community/?p=3629)
 Average/Median time (days) that issues have been opened for issues created in the last 90 days. 
-- [Issue Resolution Duration](https://chaoss.community/metric-issue-resolution-duration/)
+- [Issue Resolution Duration](https://chaoss.community/?p=3630)
 Average/Median processing time (days) for new issues created in the last 90 days, including issues closed with and without resolution
 - Number of Issue Comments
 The average number of comments per issue created in the last 90 days
-- [Issues Active](https://chaoss.community/metric-issues-active/)
+- [Issues Active](https://chaoss.community/?p=3632)
 Number of issue updates in the last 90 days.
 - CI Build Time
 The time it takes for a contribution to build
-- [Change Request Duration](https://chaoss.community/metric-change-requests-duration/)
-Change Request Age
+- [Change Requests Duration](https://chaoss.community/?p=3587)
+What is the duration of time between the moment a change request starts and the moment it is accepted or closed?
+- Change Request Age
 Average/Median processing time (days) for new change requests created in the last 90 days, including closed/accepted change requests and unresolved change requests.
-- [Change Request Reviews](https://chaoss.community/metric-change-request-reviews/)
+- [Change Request Reviews](TBD)
 The average number of review comments per pull request created in the last 90 days
-- [Change Requests Declined](https://chaoss.community/metric-change-requests-declined/)
+- [Change Requests Declined](https://chaoss.community/?p=3588)
 Number of change requests declined in the last 90 days.
-- [Change Requests Accepted](https://chaoss.community/metric-change-requests-accepted/)
+- [Change Requests Accepted](https://chaoss.community/?p=3589)
 Number of change requests accepted in the last 90 days.
-- [Collaboration Platform Activity](https://chaoss.community/metric-collaboration-platform-activity/)
+- [Collaboration Platform Activity](https://chaoss.community/?p=3484)
 Number of new mail topics created in the last 90 days
 - Event Count
 The number of online and offline events held in the past 90 days, including conferences, meet-ups

--- a/metrics-model-libs/dei-event-badging/definition/dei-event-badging.md
+++ b/metrics-model-libs/dei-event-badging/definition/dei-event-badging.md
@@ -12,17 +12,17 @@ As an event organizer, you would like to signal your attention to diversity, equ
 - Event Sponsors: It is important to know that events your organization is sponsoring are attentive to issues related to diversity, equity, and inclusion. 
 
 # Metrics in the Metrics Model
-- [Code of Conduct at Event](https://chaoss.community/metric-code-of-conduct-at-event/)
+- [Code of Conduct at Event](https://chaoss.community/?p=3492)
 Having a code of conduct represents an attention to people who would like to report inappropriate behavior.
-- [Diversity Access Tickets](https://chaoss.community/metric-diversity-access-tickets/)
+- [Diversity Access Tickets](https://chaoss.community/?p=3491)
 Diversity access tickets signal an attention to support people who may not otherwise have an opportunity to attend your event.
-- [Family Friendliness](https://chaoss.community/metric-family-friendliness/)
+- [Family Friendliness](https://chaoss.community/?p=3495)
 Family Friendliness indicates a welcoming space who may have children or be in caregiver roles. 
-- [Event Demographics](https://chaoss.community/metric-event-demographics/)
+- [Event Demographics](https://chaoss.community/?p=3507)
 Event demographics indicates that the event organizing staff is attentive and responsive to both speaker and attendee demographics.
-- [Inclusive Experience at Events](https://chaoss.community/metric-inclusive-experience-at-event/)
+- [Inclusive Experience at Events](https://chaoss.community/?p=3493)
 Attention to attendees and speakers with regard to how they are feeling at the event and giving them access to resources for any needs they have are best practices at an event.
-- [Time Inclusion for Virtual Events](https://chaoss.community/metric-time-inclusion-for-virtual-events/) 
+- [Time Inclusion for Virtual Events](https://chaoss.community/?p=3494)
 Attention to time inclusion for virtual events indicates an attention to supporting a global community of open source participants. 
 
 # Data Insights

--- a/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
+++ b/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
@@ -10,11 +10,11 @@ Development responsiveness reflects a number of things relevant to the capacity 
 - As an OSPO manager (or someone in charge of OS standards at a company/institution/org), I want to identify inactive projects for possible archiving, or remedial/supplementary support. 
 
 # Metrics in the Metrics Model
-- [Review Cycle Duration within a Change Request](https://chaoss.community/metric-review-cycle-duration-within-a-change-request/) 
+- [Review Cycle Duration within a Change Request](https://chaoss.community/?p=3445)
     - A change request is based on one or more review cycles. Within a review cycle, one or more reviewers can provide feedback on a proposed contribution. The duration of a review cycle, or the time between each new iteration of the contribution, is the basis of this metric.
-- [Change Request Duration](https://chaoss.community/metric-change-requests-duration/) 
+- [Change Request Duration](https://chaoss.community/?p=3587)
     -  The change request duration is the duration of the period since the change request started, to the moment it ended (by being accepted and being merged in the code base). This only applies to accepted change requests.
-- [Issue Response Time](https://chaoss.community/metric-issue-response-time/) 
+- [Issue Response Time](https://chaoss.community/?p=3631)
     -  Issues  are the central process of accepting code contributions.  Matters of responsiveness can be traced to urgency, maintainer availability, timezone and other influencers but ultimately reflects the reliability, and scalability of a project. This metric is an indication of how much time passes between the opening of an issue and a response from other contributors.
 - [Defect Resolution Time](https://chaoss.community/metric-defect-resolution-time/) 
     -  What is the median time between the report of a defect to the project (using the project’s defect reporting mechanism) and the time where the project resolves the defect? Note the resolution could be to address (resolve and merge) and make the update available to its users or explicitly choosing to not address (reject). 

--- a/metrics-model-libs/funding/definition/funding.md
+++ b/metrics-model-libs/funding/definition/funding.md
@@ -10,16 +10,16 @@ Funding has become an important part of open source projects. This can be in the
 - As a project maintainer, core contributors who are not compensated are less likely to maintain quality contributions. 
 
 # Metrics in the Metrics Model 
-* [Contribution Attribution](https://chaoss.community/metric-contribution-attribution/) 
+* [Contribution Attribution](https://chaoss.community/?p=3616)
     * What is the ratio of volunteer work, sponsored work, and blended work?
     * How many contributions are sponsored?
     * Who is sponsoring the contributions?
     * What types of contributions are sponsored?
-* [Organizational Influence](https://chaoss.community/metric-organizational-influence/) 
-* [Types of contributions](https://chaoss.community/metric-types-of-contributions/) 
+* [Organizational Influence](https://chaoss.community/?p=3560)
+* [Types of contributions](https://chaoss.community/?p=3432)
     * By this metric, we could see the number of organizations of different type of contributions.
-* [Labor Investment](https://chaoss.community/metric-labor-investment/) 
-* [Organizational Diversity](https://chaoss.community/metric-organizational-diversity/) 
+* [Labor Investment](https://chaoss.community/?p=3559)
+* [Organizational Diversity](https://chaoss.community/?p=3464)
     * Organizational diversity expresses how many different organizations are involved in a project and how involved different organizations are compared to one another.
 
 

--- a/metrics-model-libs/project-awareness/definition/project-awareness.md
+++ b/metrics-model-libs/project-awareness/definition/project-awareness.md
@@ -10,11 +10,11 @@ Project awareness may be used as a proxy for understanding project economic valu
 - As a person at an organization, I want to assess how much attention is being given to a project, either positively or negatively, and whether or not there have major increases or decreases in attention (e.g., from media coverage, high impact bugs, etc.)
 
 # Metrics in the Metrics Model 
-- [Clones](https://chaoss.community/metric-clones/)
-- [Technical Forks](https://chaoss.community/metric-technical-fork/) 
-- [Burstiness](https://chaoss.community/metric-burstiness/)
-- [Contributors](https://chaoss.community/metric-contributors/)
-- [Organizational Diversity](https://chaoss.community/metric-organizational-diversity/) 
+- [Clones](https://chaoss.community/?p=3429)
+- [Technical Forks](https://chaoss.community/?p=3431)
+- [Burstiness](https://chaoss.community/?p=3447)
+- [Contributors](https://chaoss.community/?p=3467)
+- [Organizational Diversity](https://chaoss.community/?p=3464)
 - Stars, badges, likes, thumbs up, thumbs down, followers, watcher, Downloads
 - Social Media Mentions/Followers
 - Installations

--- a/metrics-model-libs/project_engagement/definition/project_engagement.md
+++ b/metrics-model-libs/project_engagement/definition/project_engagement.md
@@ -10,18 +10,18 @@ Project engagement is a critical component of the sustainability of any open sou
 
 # Metrics in the Metrics Model 
 
-- [Change Requests Accepted](https://chaoss.community/metric-change-requests-accepted/)  
+- [Change Requests Accepted](https://chaoss.community/?p=3589)
 change_request_count: Accepted change requests are those that end with the corresponding changes finally merged into the code base of the project. Accepted change requests can be linked to one or more changes to the source code, those corresponding to the changes proposed and finally merged. 
 
-- [Committers](https://chaoss.community/metric-committers/)  
+- [Committers](https://chaoss.community/?p=3945)
 D0_count: Contributors who have given the project a star, or are watching or have forked the repository.  
 D1_count: Contributors who have created issues, made comments on an issue, or performed a code review.  
 D2_count: Contributors who have created a merge request and successfully merged code.  
 
-- [Contributors](https://chaoss.community/metric-contributors/)  
+- [Contributors](https://chaoss.community/?p=3467)
 contributor_count: People who contribute to the project in a number of different ways. 
 
-- [Issues Closed](https://chaoss.community/metric-issues-closed/)  
+- [Issues Closed](https://chaoss.community/?p=3633)
 closed_issues_count: Issues closed are those that changed to state closed during a certain period.
 
 - Issues Updated  
@@ -30,10 +30,10 @@ updated_issues_count: Issues updated are those that updated during a certain per
 - Issue Comments  
 issue_comment_frequency: Projects discuss how they are fixing bugs, or adding new features, in tickets in the issue tracking system. Each of these tickets (issues) are opened (submitted) by a certain person, and are later commented and annotated by many others.
 
-- [Organizational Diversity](https://chaoss.community/metric-organizational-diversity/)  
+- [Organizational Diversity](https://chaoss.community/?p=3464) 
 org_count: Organizational diversity expresses how many different organizations are involved in a project and how involved different organizations are compared to one another.
 
-- [Review Cycle Duration within a Change Request](https://chaoss.community/metric-review-cycle-duration-within-a-change-request/)  
+- [Review Cycle Duration within a Change Request](https://chaoss.community/?p=3445)
 code_review_frequency: A change request is based on one or more review cycles. Within a review cycle, one or more reviewers can provide feedback on a proposed contribution. The duration of a review cycle, or the time between each new iteration of the contribution, is the basis of this metric.
 
 - Meeting Count  


### PR DESCRIPTION
We are missing some metrics in a few of these models (which I added to the agenda for the next meeting). And we are missing a few permalinks to some metrics that have been developed already (which I opened an issue for in the website repo). 

But whenever we had a permalink available, this PR adds it to metrics models that we are close to releasing (based on #70)

Signed-off-by: Elizabeth Barron <elizabeth@naramore.net>