### PR TITLE
Fixed markdown formatting issue in Developer Responsiveness Model

### DIFF
--- a/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
+++ b/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
@@ -18,6 +18,7 @@ Development responsiveness reflects a number of things relevant to the capacity 
     -  Issues  are the central process of accepting code contributions.  Matters of responsiveness can be traced to urgency, maintainer availability, timezone and other influencers but ultimately reflects the reliability, and scalability of a project. This metric is an indication of how much time passes between the opening of an issue and a response from other contributors.
 - [Defect Resolution Time](https://chaoss.community/metric-defect-resolution-time/) 
     -  What is the median time between the report of a defect to the project (using the project’s defect reporting mechanism) and the time where the project resolves the defect? Note the resolution could be to address (resolve and merge) and make the update available to its users or explicitly choosing to not address (reject). 
+
 # Contributors
 - Emma Irwin 
 - Matt Germonprez 


### PR DESCRIPTION
The Contributors heading was indented under the metrics heading due to some issues with the Markdown formatting. This PR fixes that problem with no changes to the substance of the Model (formatting change only).