### PR TITLE
Added permanent links to the metrics models pages

### DIFF
--- a/metrics-model-libs/business-readiness/definition/business-readiness.md
+++ b/metrics-model-libs/business-readiness/definition/business-readiness.md
@@ -32,3 +32,6 @@ Individual developers want to understand code quality or community risks related
 - Matt Germonprez 
 - Sean Goggins 
 - Elizabeth Barron
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=5284**

--- a/metrics-model-libs/collaboration-development-index/definition/collaboration-development-index.md
+++ b/metrics-model-libs/collaboration-development-index/definition/collaboration-development-index.md
@@ -104,3 +104,6 @@ The number of lines of source code correlates strongly with workload, but it cor
 - Matt Germonprez
 - Sean Goggins
 - Vinod Ahuja
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4455**

--- a/metrics-model-libs/community-activity/definition/community-activity.md
+++ b/metrics-model-libs/community-activity/definition/community-activity.md
@@ -96,3 +96,6 @@ We analyzed close_issue_count and update_issue_count together, because they had 
 * Matt Germonprez
 * Kevin Lumbard
 * Vinod Ahuja
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4736**

--- a/metrics-model-libs/community-service-and-support/definition/community-service-and-support.md
+++ b/metrics-model-libs/community-service-and-support/definition/community-service-and-support.md
@@ -97,3 +97,6 @@ We put these two metrics together, that do not take the author into account. The
 - Shengbao Li
 - Matt Germonprez
 - Sean Goggins
+
+
+**To reference this metric in software or publications please use this stable URL:https://chaoss.community/?p=4740**

--- a/metrics-model-libs/dei-event-badging/definition/dei-event-badging.md
+++ b/metrics-model-libs/dei-event-badging/definition/dei-event-badging.md
@@ -47,3 +47,5 @@ As a result of the badging review process, event attendees can best understand h
 - Elizabeth Barron 
 - Sean Goggins 
 
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4719**

--- a/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
+++ b/metrics-model-libs/development-responsiveness/definition/development-responsiveness.md
@@ -27,3 +27,6 @@ Development responsiveness reflects a number of things relevant to the capacity 
 - Emma Irwin 
 - Matt Germonprez 
 - Yehui Wang
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4723**

--- a/metrics-model-libs/funding/definition/funding.md
+++ b/metrics-model-libs/funding/definition/funding.md
@@ -30,3 +30,6 @@ Funding has become an important part of open source projects. This can be in the
 - Matt Germonprez
 - Yehui Wang
 - Chenqi Shan
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4748**

--- a/metrics-model-libs/project-awareness/definition/project-awareness.md
+++ b/metrics-model-libs/project-awareness/definition/project-awareness.md
@@ -33,3 +33,6 @@ Project awareness may be used as a proxy for understanding project economic valu
 - Benjamin Mako Hill
 - Kevin Lumbard
 - Sean Goggins
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4752**

--- a/metrics-model-libs/project_engagement/definition/project_engagement.md
+++ b/metrics-model-libs/project_engagement/definition/project_engagement.md
@@ -124,3 +124,6 @@ Jun Zhong
 Matt Germonprez
 Yehui Wang 
 Liang Wang
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4744**

--- a/metrics-model-libs/safety/definition/safety.md
+++ b/metrics-model-libs/safety/definition/safety.md
@@ -40,3 +40,6 @@ Burnout is a condition of mental, emotional, and physical exhaustion resulting f
 - Lucas Gonze
 - Jun Zhong
 - Yehui Wang
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4761**

--- a/metrics-model-libs/starter-project-health/definition/starter-project-health.md
+++ b/metrics-model-libs/starter-project-health/definition/starter-project-health.md
@@ -145,3 +145,4 @@ Frequency](https://github.com/chaoss/wg-metrics-models/blob/main/metrics-model-l
 - Sophia Vargas
 
 
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=4769**

--- a/metrics-model-libs/viability/community/definition/viability-community.md
+++ b/metrics-model-libs/viability/community/definition/viability-community.md
@@ -63,3 +63,6 @@ Community metrics give an understanding of the adoption a particular project has
 - Gary White
 - Eric Sorenson
 - Matt Germonprez
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=5403**

--- a/metrics-model-libs/viability/compliance-security/definition/viability-compliance-security.md
+++ b/metrics-model-libs/viability/compliance-security/definition/viability-compliance-security.md
@@ -70,3 +70,6 @@ Intended use of this metrics model is to feed into an overall viability determin
 - Gary White
 - Eric Sorenson
 - Matt Germonprez
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=5407**

--- a/metrics-model-libs/viability/governance/definition/viability-governance.md
+++ b/metrics-model-libs/viability/governance/definition/viability-governance.md
@@ -42,3 +42,6 @@ Intended use of this metrics model is to feed into an overall viability determin
 - Gary White
 - Eric Sorenson
 - Matt Germonprez
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=5411**

--- a/metrics-model-libs/viability/strategy/definition/viability-strategy.md
+++ b/metrics-model-libs/viability/strategy/definition/viability-strategy.md
@@ -56,3 +56,6 @@ Intended use of this metrics model is to feed into an overall viability determin
 - Gary White
 - Eric Sorenson
 - Matt Germonprez
+
+
+**To reference this metric in software or publications please use this stable URL: https://chaoss.community/?p=5416**


### PR DESCRIPTION
This PR resolves #102 

**Notes for reviewers:**
1. I've added permanent links to all the metrics models pages.
2. I noticed that the metric "safety" appears twice in the csv file. They have different web & permanent links (one is just "safety" and the other is "community safety"). But the GitHub directories are the same; they both lead to the safety.md file. There's just one folder for safety. There's none for community safety.
![image](https://github.com/chaoss/wg-metrics-models/assets/122698422/9fcc71cf-810d-4c6f-a3fb-112177423739)
3. I also noticed that there's a "community welcomingness" folder but it wasn't captured in the csv file. Is this intentional?
![image](https://github.com/chaoss/wg-metrics-models/assets/122698422/af6c819a-aac0-4050-820a-f59e44ac739d)


@geekygirldawn for your review.