### PR TITLE
Updated content on the business-readiness.md file

### DIFF
--- a/metrics-model-libs/business-readiness/definition/business-readiness.md
+++ b/metrics-model-libs/business-readiness/definition/business-readiness.md
@@ -20,7 +20,7 @@ Individual developers want to understand code quality or community risks related
   - [OSI Approved Licenses](https://chaoss.community/?p=3962) 
 
 - Risk assessment 
-  - [Bus Factor](https://chaoss.community/?p=3944) 
+  - [Contributor Absence Factor](https://chaoss.community/?p=3944) 
   - [Committers](https://chaoss.community/?p=3945)
   - [Elephant Factor](https://chaoss.community/?p=3940) 
 


### PR DESCRIPTION
Replaced "bus factor" with "contributor absence factor".  

Signed-off-by: Precious Onyewuchi uniquep201@gmail.com  